### PR TITLE
Easier building and deploying on linux/osx

### DIFF
--- a/ENet/CMakeLists.txt
+++ b/ENet/CMakeLists.txt
@@ -1,0 +1,76 @@
+cmake_minimum_required(VERSION 2.6)
+
+project(enet)
+set(CMAKE_BUILD_TYPE Release)
+
+# The "configure" step.
+include(CheckFunctionExists)
+include(CheckStructHasMember)
+include(CheckTypeSize)
+check_function_exists("fcntl" HAS_FCNTL)
+check_function_exists("poll" HAS_POLL)
+check_function_exists("getaddrinfo" HAS_GETADDRINFO)
+check_function_exists("getnameinfo" HAS_GETNAMEINFO)
+check_function_exists("gethostbyname_r" HAS_GETHOSTBYNAME_R)
+check_function_exists("gethostbyaddr_r" HAS_GETHOSTBYADDR_R)
+check_function_exists("inet_pton" HAS_INET_PTON)
+check_function_exists("inet_ntop" HAS_INET_NTOP)
+check_struct_has_member("struct msghdr" "msg_flags" "sys/types.h;sys/socket.h" HAS_MSGHDR_FLAGS)
+set(CMAKE_EXTRA_INCLUDE_FILES "sys/types.h" "sys/socket.h")
+check_type_size("socklen_t" HAS_SOCKLEN_T BUILTIN_TYPES_ONLY)
+unset(CMAKE_EXTRA_INCLUDE_FILES)
+
+IF(WIN32)
+  LINK_LIBRARIES(ws2_32)
+  LINK_LIBRARIES(winmm)
+ENDIF()
+
+if(MSVC)
+	add_definitions(-W3)
+else()
+	add_definitions(-Wno-error)
+endif()
+ 
+if(HAS_FCNTL)
+    add_definitions(-DHAS_FCNTL=1)
+endif()
+if(HAS_POLL)
+    add_definitions(-DHAS_POLL=1)
+endif()
+if(HAS_GETNAMEINFO)
+    add_definitions(-DHAS_GETNAMEINFO=1)
+endif()
+if(HAS_GETADDRINFO)
+    add_definitions(-DHAS_GETADDRINFO=1)
+endif()
+if(HAS_GETHOSTBYNAME_R)
+    add_definitions(-DHAS_GETHOSTBYNAME_R=1)
+endif()
+if(HAS_GETHOSTBYADDR_R)
+    add_definitions(-DHAS_GETHOSTBYADDR_R=1)
+endif()
+if(HAS_INET_PTON)
+    add_definitions(-DHAS_INET_PTON=1)
+endif()
+if(HAS_INET_NTOP)
+    add_definitions(-DHAS_INET_NTOP=1)
+endif()
+if(HAS_MSGHDR_FLAGS)
+    add_definitions(-DHAS_MSGHDR_FLAGS=1)
+endif()
+if(HAS_SOCKLEN_T)
+    add_definitions(-DHAS_SOCKLEN_T=1)
+endif()
+ 
+include_directories(${PROJECT_SOURCE_DIR}/include)
+ 
+add_library(enet SHARED
+        callbacks.c
+        host.c
+        list.c
+        packet.c
+        peer.c
+        protocol.c
+        unix.c
+        win32.c
+    )

--- a/ENet/CMakeLists.txt
+++ b/ENet/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 
-project(libenet)
+project(enet)
 set(CMAKE_BUILD_TYPE Release)
 
 # The "configure" step.
@@ -64,7 +64,7 @@ endif()
  
 include_directories(${PROJECT_SOURCE_DIR}/include)
  
-add_library(libenet SHARED
+add_library(enet SHARED
         callbacks.c
         host.c
         list.c

--- a/ENet/CMakeLists.txt
+++ b/ENet/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
 
-project(enet)
+project(libenet)
 set(CMAKE_BUILD_TYPE Release)
 
 # The "configure" step.
@@ -64,7 +64,7 @@ endif()
  
 include_directories(${PROJECT_SOURCE_DIR}/include)
  
-add_library(enet SHARED
+add_library(libenet SHARED
         callbacks.c
         host.c
         list.c

--- a/ENet/enet.vcxproj
+++ b/ENet/enet.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -19,13 +19,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/ENet/enet.vcxproj
+++ b/ENet/enet.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -19,13 +19,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/ENetCS/Native.cs
+++ b/ENetCS/Native.cs
@@ -9,7 +9,7 @@ namespace ENet
 {
     public static unsafe partial class Native
     {
-        private const string LIB = "ENet.dll";
+        private const string LIB = "libenet";
 
         public const int ENET_PEER_PACKET_THROTTLE_SCALE = 32;
         public const int ENET_PEER_PACKET_THROTTLE_ACCELERATION = 2;

--- a/Package.nuspec
+++ b/Package.nuspec
@@ -19,6 +19,6 @@
   </metadata>
   <files>
     <file src="Release/ENetCS.dll" target="lib/net461/ENetCS.dll" />
-    <file src="Release/ENet.dll" target="lib/native/ENet.dll" />
+    <file src="Release/libenet.dll" target="lib/native/libenet.dll" />
   </files>
 </package>

--- a/enet-cs.sln
+++ b/enet-cs.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ENetCS", "ENetCS\ENetCS.csproj", "{D3AFF7FA-96F6-42B8-B03C-E508DC80EC3A}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "enet", "ENet\enet.vcxproj", "{64A16876-9AA1-4321-902A-AE0A6F0A7BBB}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
Changed enet library to ``libenet`` without file extension(and lower caps) as to allow automatic loading of required library.